### PR TITLE
fix: the SSL certificate has been renewed, no longer bypass the error

### DIFF
--- a/lib/api/client.dart
+++ b/lib/api/client.dart
@@ -58,9 +58,6 @@ class Request {
       //Ignore the exception since this happens when the certificate is already there
     }
     final httpClient = HttpClient(context: context);
-    httpClient.badCertificateCallback = ((X509Certificate cert, String host, int port) {
-      return host == 'mobilite.kosmoseducation.com';
-    });
     final client = IOClient(httpClient);
     bool success = false;
     do {
@@ -275,11 +272,6 @@ class Client {
       //Ignore the exception since this happens when the certificate is already there
     }
     final httpClient = HttpClient(context: context);
-
-    httpClient.badCertificateCallback = ((X509Certificate cert, String host, int port) {
-      return host == 'mobilite.kosmoseducation.com';
-    });
-
     final client = IOClient(httpClient);
     bool success = false;
     do {


### PR DESCRIPTION
Hello,

Kosmos Education has renewed the SSL certificate with the Let's Encrypt certificate authority for the domain "mobilite.kosmoseducation.com".  
As a reminder, this domain is used by the mobile applications of certain establishments such as the Lycée Jean Renoir de Munich for example.  
So it is no longer necessary to bypass the http client error.


New certificate:
> Issuer: R3
> Valid from: 21/11/2022
> Valid to: 19/02/2023
> SHA-1 thumbprint: 49CDE78D7BB356B0E050234B28C00B812D8AAE6A

Closes #6 